### PR TITLE
Update startstopX.sh

### DIFF
--- a/www/macros/startstopX.sh
+++ b/www/macros/startstopX.sh
@@ -1,36 +1,42 @@
 #!/bin/bash
-# example start up script which converts any existing .h264 files into MP4
-#Check if script already running
-mypidfile=/var/www/html/macros/startstopX.sh.pid
 
-NOW=`date +"-%Y/%m/%d %H:%M:%S-"`
-if [ -f $mypidfile ]; then
-        echo "${NOW} Script already running..." >> /var/www/html/scheduleLog.txt
-        exit
+# Run this after an RPiCamControl update to re-patch things I've changed
+
+# First auto-update and restart
+SELF=`basename "$0"`
+if [ "$1" != "HasBeenUpdated" ]; then
+	echo Updating "$SELF" ...
+	cd ~/bin
+	fetch "$SELF" ras 744 nobackup
+	"$SELF" HasBeenUpdated
+	exit
 fi
-#Remove PID file when exiting
-trap "rm -f -- '$mypidfile'" EXIT
 
-echo $$ > "$mypidfile"
 
-#Do conversion
-if [ "$1" == "start" ]; then
-  cd $(dirname $(readlink -f $0))
-  cd ../media
-  shopt -s nullglob
-  for f in *.h264
-    do
-      f1=${f%.*}
-        NOW=`date +"-%Y/%m/%d %H:%M:%S-"`
-        echo "${NOW} Converting $f" >> /var/www/html/scheduleLog.txt
-        #set -e;MP4Box -fps 25 -add $f $f1 > /dev/null 2>&1;rm $f;
-        if MP4Box -fps 25 -add $f $f1; then
-                NOW=`date +"-%Y/%m/%d %H:%M:%S-"`
-                echo "${NOW} Conversion complete, removing $f" >> /var/www/html/scheduleLog.txt
-                rm $f
-        else
-                NOW=`date +"-%Y/%m/%d %H:%M:%S-"`
-                echo "${NOW} Error with $f" >> /var/www/html/scheduleLog.txt
-        fi
-    done
+if [ -e /var/www/birdcam/diskUsage.txt.save ]; then
+	echo Restoring diskUsage.txt.save ...
+	sudo cp /var/www/birdcam/diskUsage.txt.save /var/www/birdcam/diskUsage.txt
+fi
+
+
+echo Patching preview.php ...
+sudo cp /var/www/birdcam/preview.php /var/www/birdcam/preview.php.orig
+
+# Make the "Delete Selected" button yellow instead of red
+sudo sed -i 's/'\
+$'button class=\'btn btn-danger\' type=\'submit\' name=\'action\' value=\'deleteSel\'/'\
+$'button class=\'btn btn-warning\' type=\'submit\' name=\'action\' value=\'deleteSel\'/' \
+/var/www/birdcam/preview.php
+
+# Make the "Delete All" NOT recursive!
+sudo sed -i 's/'\
+'maintainFolders(MEDIA_PATH, true, true);/'\
+'maintainFolders(MEDIA_PATH, true, false);/' \
+/var/www/birdcam/preview.php
+
+
+
+if [ -e /var/www/birdcam/macros/startstopX.sh ]; then
+	sudo rm -f /var/www/birdcam/macros/Xstartstop.sh
+	sudo mv -f /var/www/birdcam/macros/startstopX.sh Xstartstop.sh
 fi


### PR DESCRIPTION
This script was missing the .mp4 extension for the output files. In addition it didn't work if the code was installed somewhere other than /var/www/html. This corrects both those problems.

However, this script may be completely obsolete regardless; in my experience it seems like orphaned .h264 files automatically get converted after a restart anyway, even without enabling this script. (I haven't tested that theory extensively though.)

If there are cases where this script is still needed, these changes should make it more useful. If not, perhaps this file should just be deleted from this distribution.